### PR TITLE
#62 fixed the error handling+ fixed eslint

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: ["error", { "args": "after-used" }] */
+
 const express = require('express');
 const path = require('path');
 const cookieParser = require('cookie-parser');
@@ -11,11 +13,14 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+
+app.use(express.static(path.join(__dirname, '..', 'client/build')));
+
 app.use('/', indexRouter);
 
 // error handlerfunction
-app.use((err, req, res) => {
+// eslint-disable-next-line
+app.use((err, req, res, next) => {
   res.status(err.status || 500);
   res.send('error');
 });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,10 +1,11 @@
 const express = require('express');
+const path = require('path');
 
 const router = express.Router();
 const voters = require('../model/voters');
 /* GET home page. */
 router.get('/', (req, res) => {
-  res.send('helloww');
+  res.sendFile(path.join(__dirname, '..', '..', 'client/build/index.html'));
 });
 router.get('/voters', (req, res) => {
   res.json(voters);


### PR DESCRIPTION
in this PR **first** we fixed the error handling  by adding the fourth key so it know it's an error handling.
`(err,req,res,next)`
.
the **second** issue was about fixing eslint configuration and cancel the error message because `next` weren't used after defining it.
